### PR TITLE
Updated Core nuget package.

### DIFF
--- a/Vasont.Inspire.SDK.csproj
+++ b/Vasont.Inspire.SDK.csproj
@@ -1,22 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461;net48</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.5.9</Version>
+    <Version>1.6.0</Version>
     <Authors>Vasont Systems</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/vasont-systems/Vasont.Inspire.SDK</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>CCMS</PackageTags>
-    <PackageReleaseNotes>Added extension methods for working with file extension blacklist configurations.</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated Core nuget packages.
+Dropping support for .NET standard 2.0 and 4.6.1. This is .NET Core 2.2 which is already flagged as deprecated. Support for LTS will be our only standard from here on out. Since .NET 5 is a unified framework to Core, we're only supporting .NET Core Standard from now on. Please update to a .NET Core framework development cycle.</PackageReleaseNotes>
     <PackageProjectUrl>https://dev.vasont.com/</PackageProjectUrl>
     <Description>Contains the Vasont Inspire SDK Client for integrating with Vasont Inspire CCMS REST Web API.</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="4.1.1" />
-    <PackageReference Include="Vasont.Inspire.Models" Version="1.1.7" />
+    <PackageReference Include="Vasont.Inspire.Models" Version="1.1.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Dropping support for .NET standard 2.0. This is .NET Core 2.2 which is already flagged as deprecated. Support for LTS will be our only standard from here on out.