### PR TITLE
Cleanup method names

### DIFF
--- a/src/Components/ComponentExtensions.cs
+++ b/src/Components/ComponentExtensions.cs
@@ -172,7 +172,7 @@ namespace Vasont.Inspire.SDK.Components
         /// <summary>
         /// This method is used to retrieve the detail of the specific component.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="componentId">The component identifier.</param>
         /// <returns>Returns the <see cref="DetailedComponentModel"/> object.</returns>
         [Obsolete("This method is obsolete. Please use FindComponentDetail() going forward. This method will be removed in a future release.")]
@@ -184,7 +184,7 @@ namespace Vasont.Inspire.SDK.Components
         /// <summary>
         /// This method is used to retrieve the detail of the specific component.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="componentId">The component identifier.</param>
         /// <returns>Returns the <see cref="DetailedComponentModel"/> object.</returns>
         public static DetailedComponentModel FindComponentDetail(this InspireClient client, long componentId)
@@ -725,7 +725,7 @@ namespace Vasont.Inspire.SDK.Components
         /// <summary>
         /// This method is used to update the specified component tags.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="componentId">The component identifier.</param>
         /// <param name="inputModel">The input model.</param>
         /// <returns>Returns the updated <see cref="ComponentTagModel"/> object.</returns>
@@ -743,7 +743,7 @@ namespace Vasont.Inspire.SDK.Components
         /// <summary>
         /// This method is used to update the specified component tags.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="componentId">The component identifier.</param>
         /// <param name="inputModel">The input model.</param>
         /// <returns>Returns the updated <see cref="ComponentTagModel"/> object.</returns>

--- a/src/Components/ComponentExtensions.cs
+++ b/src/Components/ComponentExtensions.cs
@@ -30,7 +30,18 @@ namespace Vasont.Inspire.SDK.Components
         /// </summary>
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="MinimalComponentTypeModel"/> minimal component type models.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveComponentTypes() going forward. This method will be removed in a future release.")]
         public static List<MinimalComponentTypeModel> GetComponentTypes(this InspireClient client)
+        {
+            return RetrieveComponentTypes(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve and return minimal models for component types.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <returns>Returns a list of <see cref="MinimalComponentTypeModel"/> minimal component type models.</returns>
+        public static List<MinimalComponentTypeModel> RetrieveComponentTypes(this InspireClient client)
         {
             var request = client.CreateRequest($"/ComponentTypes");
             return client.RequestContent<List<MinimalComponentTypeModel>>(request);
@@ -45,7 +56,18 @@ namespace Vasont.Inspire.SDK.Components
         /// </summary>
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="WorkflowTemplateModel"/> objects.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveComponentWorkflowTemplates() going forward. This method will be removed in a future release.")]
         public static List<WorkflowTemplateModel> GetComponentWorkflowTemplates(this InspireClient client)
+        {
+            return RetrieveComponentWorkflowTemplates(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the component workflow templates.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <returns>Returns a list of <see cref="WorkflowTemplateModel"/> objects.</returns>
+        public static List<WorkflowTemplateModel> RetrieveComponentWorkflowTemplates(this InspireClient client)
         {
             var request = client.CreateRequest($"/Components/WorkflowTemplates");
             return client.RequestContent<List<WorkflowTemplateModel>>(request);
@@ -57,7 +79,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="componentId">Contains the unique identity of the component.</param>
         /// <returns>Returns a list of <see cref="WorkflowModel"/> objects.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentWorkflowTemplate() going forward. This method will be removed in a future release.")]
         public static WorkflowModel GetComponentWorkflowTemplate(this InspireClient client, long componentId)
+        {
+            return FindComponentWorkflowTemplate(client, componentId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific component's workflow templates.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="componentId">Contains the unique identity of the component.</param>
+        /// <returns>Returns a list of <see cref="WorkflowModel"/> objects.</returns>
+        public static WorkflowModel FindComponentWorkflowTemplate(this InspireClient client, long componentId)
         {
             var request = client.CreateRequest($"/Components/{componentId}/WorkflowTemplate");
             return client.RequestContent<WorkflowModel>(request);
@@ -69,7 +103,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="documentTypes">Contains a comma delimited list of document types that will be used to filter the results.</param>
         /// <returns>Returns the a list of <see cref="MinimalComponentModel"/> objects.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentTemplates() going forward. This method will be removed in a future release.")]
         public static List<MinimalComponentModel> GetComponentTemplates(this InspireClient client, string documentTypes = "")
+        {
+            return FindComponentTemplates(client, documentTypes);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the component templates based on the supplied document types.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="documentTypes">Contains a comma delimited list of document types that will be used to filter the results.</param>
+        /// <returns>Returns the a list of <see cref="MinimalComponentModel"/> objects.</returns>
+        public static List<MinimalComponentModel> FindComponentTemplates(this InspireClient client, string documentTypes = "")
         {
             var request = client.CreateRequest($"/Components/Templates/{documentTypes}");
             return client.RequestContent<List<MinimalComponentModel>>(request);
@@ -81,7 +127,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="componentIds">The list of component identifiers.</param>
         /// <returns>Returns a <see cref="BatchComponentsResultModel"/> object containing a list of requested components.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponents() going forward. This method will be removed in a future release.")]
         public static BatchComponentsResultModel GetComponents(this InspireClient client, BatchComponentsRequestModel componentIds)
+        {
+            return FindComponents(client, componentIds);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specified batch of requested components.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="componentIds">The list of component identifiers.</param>
+        /// <returns>Returns a <see cref="BatchComponentsResultModel"/> object containing a list of requested components.</returns>
+        public static BatchComponentsResultModel FindComponents(this InspireClient client, BatchComponentsRequestModel componentIds)
         {
             var request = client.CreateRequest($"/Components/Batch", HttpMethod.Post);
             return client.RequestContent<BatchComponentsRequestModel, BatchComponentsResultModel>(request, componentIds);
@@ -93,7 +151,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="componentId">The component identity.</param>
         /// <returns>Returns a list of <see cref="MinimalComponentModel"/> objects.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponent() going forward. This method will be removed in a future release.")]
         public static MinimalComponentModel GetComponent(this InspireClient client, long componentId)
+        {
+            return FindComponent(client, componentId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve minimal detail about a specific component.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="componentId">The component identity.</param>
+        /// <returns>Returns a list of <see cref="MinimalComponentModel"/> objects.</returns>
+        public static MinimalComponentModel FindComponent(this InspireClient client, long componentId)
         {
             var request = client.CreateRequest($"/Components/{componentId}");
             return client.RequestContent<MinimalComponentModel>(request);
@@ -105,7 +175,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client">The client.</param>
         /// <param name="componentId">The component identifier.</param>
         /// <returns>Returns the <see cref="DetailedComponentModel"/> object.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentDetail() going forward. This method will be removed in a future release.")]
         public static DetailedComponentModel GetComponentDetail(this InspireClient client, long componentId)
+        {
+            return FindComponentDetail(client, componentId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the detail of the specific component.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="componentId">The component identifier.</param>
+        /// <returns>Returns the <see cref="DetailedComponentModel"/> object.</returns>
+        public static DetailedComponentModel FindComponentDetail(this InspireClient client, long componentId)
         {
             var request = client.CreateRequest($"/Components/{componentId}/Details");
             return client.RequestContent<DetailedComponentModel>(request);
@@ -117,7 +199,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="componentId">The component identity.</param>
         /// <returns>Returns an array of bytes that represent the content of the component.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentContent() going forward. This method will be removed in a future release.")]
         public static byte[] GetComponentContent(this InspireClient client, long componentId)
+        {
+            return FindComponentContent(client, componentId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the content from a specific component.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="componentId">The component identity.</param>
+        /// <returns>Returns an array of bytes that represent the content of the component.</returns>
+        public static byte[] FindComponentContent(this InspireClient client, long componentId)
         {
             var request = client.CreateRequest($"/Components/{componentId}/Content");
             return client.RequestContent<byte[]>(request);
@@ -129,7 +223,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="componentId">The component identity.</param>
         /// <returns>Returns the <see cref="PermissionUpdateModel"/> object.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentPermissions() going forward. This method will be removed in a future release.")]
         public static PermissionUpdateModel GetComponentPermissions(this InspireClient client, long componentId)
+        {
+            return FindComponentPermissions(client, componentId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the permission details for a specific component.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="componentId">The component identity.</param>
+        /// <returns>Returns the <see cref="PermissionUpdateModel"/> object.</returns>
+        public static PermissionUpdateModel FindComponentPermissions(this InspireClient client, long componentId)
         {
             var request = client.CreateRequest($"/Components/{componentId}/Permissions");
             return client.RequestContent<PermissionUpdateModel>(request);
@@ -142,7 +248,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="componentId">The list of component identifier.</param>
         /// <param name="allowedElements">Contains an optional list of allowed element names.</param>
         /// <returns>Returns a <see cref="BatchComponentsResultModel"/> object containing a list of requested components.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentElements() going forward. This method will be removed in a future release.")]
         public static List<XmlComponentElementModel> GetComponentElements(this InspireClient client, long componentId, List<string> allowedElements)
+        {
+            return FindComponentElements(client, componentId, allowedElements);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the specified components elements.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="componentId">The list of component identifier.</param>
+        /// <param name="allowedElements">Contains an optional list of allowed element names.</param>
+        /// <returns>Returns a <see cref="BatchComponentsResultModel"/> object containing a list of requested components.</returns>
+        public static List<XmlComponentElementModel> FindComponentElements(this InspireClient client, long componentId, List<string> allowedElements)
         {
             var request = client.CreateRequest($"/Components/{componentId}/Elements", HttpMethod.Post);
             return client.RequestContent<List<string>, List<XmlComponentElementModel>>(request, allowedElements);
@@ -172,7 +291,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="componentId">Contains the component identity.</param>
         /// <param name="forceReload">Contains a value indicating whether the configuration cache is bypassed and reloaded.</param>
         /// <returns>Returns the <see cref="ComponentConfigurationModel"/> object.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentConfiguration() going forward. This method will be removed in a future release.")]
         public static ComponentConfigurationModel GetComponentConfiguration(this InspireClient client, long componentId, bool forceReload = false)
+        {
+            return FindComponentConfiguration(client, componentId, forceReload);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a component configuration for a specified component
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="componentId">Contains the component identity.</param>
+        /// <param name="forceReload">Contains a value indicating whether the configuration cache is bypassed and reloaded.</param>
+        /// <returns>Returns the <see cref="ComponentConfigurationModel"/> object.</returns>
+        public static ComponentConfigurationModel FindComponentConfiguration(this InspireClient client, long componentId, bool forceReload = false)
         {
             var request = client.CreateRequest($"/Components/{componentId}/Configuration?force={forceReload}");
             return client.RequestContent<ComponentConfigurationModel>(request);
@@ -472,7 +604,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="workerKey">Contains the import worker key to find.</param>
         /// <returns>Returns a <see cref="MinimalWorkerStateModel"/> of type <see cref="MinimalImportStateModel"/>.</returns>
+        [Obsolete("This method is obsolete. Please use FindImportState() going forward. This method will be removed in a future release.")]
         public static MinimalWorkerStateModel<MinimalImportStateModel> GetImportState(this InspireClient client, string workerKey)
+        {
+            return FindImportState(client, workerKey);
+        }
+
+        /// <summary>
+        /// This method is used to get the state of an import worker process.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="workerKey">Contains the import worker key to find.</param>
+        /// <returns>Returns a <see cref="MinimalWorkerStateModel"/> of type <see cref="MinimalImportStateModel"/>.</returns>
+        public static MinimalWorkerStateModel<MinimalImportStateModel> FindImportState(this InspireClient client, string workerKey)
         {
             if (string.IsNullOrEmpty(workerKey))
             {
@@ -491,17 +635,27 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="inputModel">Contains the <see cref="WorkerStateModel"/> input.</param>
         /// <returns>Returns a <see cref="MinimalWorkerStateModel"/> of type <see cref="MinimalImportStateModel"/>.</returns>
+        [Obsolete("This method is obsolete. Please use FindImportState() going forward. This method will be removed in a future release.")]
         public static MinimalWorkerStateModel<MinimalImportStateModel> GetImportState(this InspireClient client, WorkerStateModel inputModel)
+        {
+            return FindImportState(client, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to get the state of an import worker process.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="inputModel">Contains the <see cref="WorkerStateModel"/> input.</param>
+        /// <returns>Returns a <see cref="MinimalWorkerStateModel"/> of type <see cref="MinimalImportStateModel"/>.</returns>
+        public static MinimalWorkerStateModel<MinimalImportStateModel> FindImportState(this InspireClient client, WorkerStateModel inputModel)
         {
             if (inputModel == null)
             {
                 throw new ArgumentNullException(nameof(inputModel));
             }
-
-            string encodedWorkerKey = Uri.EscapeUriString(inputModel.Key);
-            var request = client.CreateRequest($"/Components/Import?workerKey={encodedWorkerKey}", HttpMethod.Get);
-
-            return client.RequestContent<MinimalWorkerStateModel<MinimalImportStateModel>>(request);
+            
+            // Call existing FindImportState using the Key from the model
+            return FindImportState(client, inputModel.Key);
         }
 
         /// <summary>
@@ -510,7 +664,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="workerKey">Contains the export worker key to find.</param>
         /// <returns>Returns a <see cref="MinimalWorkerStateModel"/> of type <see cref="MinimalExportStateModel"/>.</returns>
+        [Obsolete("This method is obsolete. Please use FindExportState() going forward. This method will be removed in a future release.")]
         public static MinimalWorkerStateModel<MinimalExportStateModel> GetExportState(this InspireClient client, string workerKey)
+        {
+            return FindExportState(client, workerKey);
+        }
+
+        /// <summary>
+        /// This method is used to get the state of an export worker process.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="workerKey">Contains the export worker key to find.</param>
+        /// <returns>Returns a <see cref="MinimalWorkerStateModel"/> of type <see cref="MinimalExportStateModel"/>.</returns>
+        public static MinimalWorkerStateModel<MinimalExportStateModel> FindExportState(this InspireClient client, string workerKey)
         {
             if (string.IsNullOrEmpty(workerKey))
             {
@@ -529,17 +695,27 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="inputModel">Contains the <see cref="WorkerStateModel"/> input.</param>
         /// <returns>Returns a <see cref="MinimalWorkerStateModel"/> of type <see cref="MinimalExportStateModel"/>.</returns>
+        [Obsolete("This method is obsolete. Please use FindExportState() going forward. This method will be removed in a future release.")]
         public static MinimalWorkerStateModel<MinimalExportStateModel> GetExportState(this InspireClient client, WorkerStateModel inputModel)
+        {
+            return FindExportState(client, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to get the state of an export worker process.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="inputModel">Contains the <see cref="WorkerStateModel"/> input.</param>
+        /// <returns>Returns a <see cref="MinimalWorkerStateModel"/> of type <see cref="MinimalExportStateModel"/>.</returns>
+        public static MinimalWorkerStateModel<MinimalExportStateModel> FindExportState(this InspireClient client, WorkerStateModel inputModel)
         {
             if (inputModel == null)
             {
                 throw new ArgumentNullException(nameof(inputModel));
             }
 
-            string encodedWorkerKey = Uri.EscapeUriString(inputModel.Key);
-            var request = client.CreateRequest($"/Components/Export?workerKey={encodedWorkerKey}", HttpMethod.Get);
-
-            return client.RequestContent<MinimalWorkerStateModel<MinimalExportStateModel>>(request);
+            // Call existing FindExportState using the Key from the model
+            return FindExportState(client, inputModel.Key);
         }
 
         #endregion Public Component Extension Methods
@@ -624,7 +800,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
         /// <returns>Returns a <see cref="ComponentRelationsResultModel"/> model.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        [Obsolete("This method is obsolete. Please use FindComponentRelations() going forward. This method will be removed in a future release.")]
         public static ComponentRelationsResultModel GetComponentRelations(this InspireClient client, ComponentRelationsQueryModel inputModel)
+        {
+            return FindComponentRelations(client, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the requested component relations.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
+        /// <returns>Returns a <see cref="ComponentRelationsResultModel"/> model.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        public static ComponentRelationsResultModel FindComponentRelations(this InspireClient client, ComponentRelationsQueryModel inputModel)
         {
             if (inputModel == null)
             {
@@ -642,7 +831,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
         /// <returns>Returns an array of bytes that represent the content of the component relation report.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        [Obsolete("This method is obsolete. Please use FindComponentRelationsReport() going forward. This method will be removed in a future release.")]
         public static byte[] GetComponentRelationsReport(this InspireClient client, ComponentRelationsQueryModel inputModel)
+        {
+            return FindComponentRelationsReport(client, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the relations report for the specified component and return as a CSV formatted report file contents.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
+        /// <returns>Returns an array of bytes that represent the content of the component relation report.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        public static byte[] FindComponentRelationsReport(this InspireClient client, ComponentRelationsQueryModel inputModel)
         {
             if (inputModel == null)
             {
@@ -660,7 +862,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
         /// <returns>Returns a <see cref="ComponentDependenciesResultModel"/> model.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        [Obsolete("This method is obsolete. Please use FindComponentDependencies() going forward. This method will be removed in a future release.")]
         public static ComponentDependenciesResultModel GetComponentDependencies(this InspireClient client, ComponentRelationsQueryModel inputModel)
+        {
+            return FindComponentDependencies(client, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the requested component dependencies.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
+        /// <returns>Returns a <see cref="ComponentDependenciesResultModel"/> model.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        public static ComponentDependenciesResultModel FindComponentDependencies(this InspireClient client, ComponentRelationsQueryModel inputModel)
         {
             if (inputModel == null)
             {
@@ -678,7 +893,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
         /// <returns>Returns an array of bytes that represent the content of the component dependency report.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        [Obsolete("This method is obsolete. Please use FIndComponentDependenciesReport() going forward. This method will be removed in a future release.")]
         public static byte[] GetComponentDependenciesReport(this InspireClient client, ComponentRelationsQueryModel inputModel)
+        {
+            return FIndComponentDependenciesReport(client, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the dependencies for the specified component and return as a CSV formatted report file contents.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
+        /// <returns>Returns an array of bytes that represent the content of the component dependency report.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        public static byte[] FIndComponentDependenciesReport(this InspireClient client, ComponentRelationsQueryModel inputModel)
         {
             if (inputModel == null)
             {
@@ -695,7 +923,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="sourceComponentId">Contains the source component identity to retrieve branch relations.</param>
         /// <returns>Returns a <see cref="List{BranchReferenceModel}"/> model.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentBranchRelations() going forward. This method will be removed in a future release.")]
         public static List<BranchReferenceModel> GetComponentBranchRelations(this InspireClient client, long sourceComponentId)
+        {
+            return FindComponentBranchRelations(client, sourceComponentId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the branch relations for the specified component.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="sourceComponentId">Contains the source component identity to retrieve branch relations.</param>
+        /// <returns>Returns a <see cref="List{BranchReferenceModel}"/> model.</returns>
+        public static List<BranchReferenceModel> FindComponentBranchRelations(this InspireClient client, long sourceComponentId)
         {
             var request = client.CreateRequest($"/Components/{sourceComponentId}/BranchRelations", HttpMethod.Get);
             return client.RequestContent<List<BranchReferenceModel>>(request);
@@ -708,7 +948,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
         /// <returns>Returns a <see cref="ComponentRelationsResultModel"/> model.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        [Obsolete("This method is obsolete. Please use FindComponentBranches() going forward. This method will be removed in a future release.")]
         public static ComponentRelationsResultModel GetComponentBranches(this InspireClient client, ComponentRelationsQueryModel inputModel)
+        {
+            return FindComponentBranches(client, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to get the branches for the specified component.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
+        /// <returns>Returns a <see cref="ComponentRelationsResultModel"/> model.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        public static ComponentRelationsResultModel FindComponentBranches(this InspireClient client, ComponentRelationsQueryModel inputModel)
         {
             if (inputModel == null)
             {
@@ -726,7 +979,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
         /// <returns>Returns an array of bytes that represent the content of the component branches report.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        [Obsolete("This method is obsolete. Please use FindComponentBranchesReport() going forward. This method will be removed in a future release.")]
         public static byte[] GetComponentBranchesReport(this InspireClient client, ComponentRelationsQueryModel inputModel)
+        {
+            return FindComponentBranchesReport(client, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the branches for the specified component and return as a CSV formatted report file contents.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
+        /// <returns>Returns an array of bytes that represent the content of the component branches report.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        public static byte[] FindComponentBranchesReport(this InspireClient client, ComponentRelationsQueryModel inputModel)
         {
             if (inputModel == null)
             {
@@ -748,7 +1014,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
         /// <returns>Returns a <see cref="ComponentRelationsResultModel"/> model.</returns>
         /// <exception cref="ArgumentNullException">thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        [Obsolete("This method is obsolete. Please use RetrieveComponentTypes() going forward. This method will be removed in a future release.")]
         public static ComponentRelationsResultModel GetComponentTranslations(this InspireClient client, ComponentRelationsQueryModel inputModel)
+        {
+            return FindComponentTranslations(client, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the translations for the specified component.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
+        /// <returns>Returns a <see cref="ComponentRelationsResultModel"/> model.</returns>
+        /// <exception cref="ArgumentNullException">thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        public static ComponentRelationsResultModel FindComponentTranslations(this InspireClient client, ComponentRelationsQueryModel inputModel)
         {
             if (inputModel == null)
             {
@@ -766,7 +1045,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
         /// <returns>Returns an array of bytes that represent the content of the component translations report.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        [Obsolete("This method is obsolete. Please use FindComponentTranslationsReport() going forward. This method will be removed in a future release.")]
         public static byte[] GetComponentTranslationsReport(this InspireClient client, ComponentRelationsQueryModel inputModel)
+        {
+            return FindComponentTranslationsReport(client, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to get the translations for the specified component and return as a CSV formatted report file contents.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="inputModel">The <see cref="ComponentRelationsQueryModel"/> input model.</param>
+        /// <returns>Returns an array of bytes that represent the content of the component translations report.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentRelationsQueryModel"/> is not set.</exception>
+        public static byte[] FindComponentTranslationsReport(this InspireClient client, ComponentRelationsQueryModel inputModel)
         {
             if (inputModel == null)
             {
@@ -789,7 +1081,21 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="usePostMethod">Contains a value indicating whether the POST method is used in query.</param>
         /// <returns>Returns a <see cref="ComponentHistoryResultModel"/> model.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentHistoryQueryModel"/> is not set.</exception>
+        [Obsolete("This method is obsolete. Please use FindComponentHistory() going forward. This method will be removed in a future release.")]
         public static ComponentHistoryResultModel GetComponentHistory(this InspireClient client, ComponentHistoryQueryModel inputModel, bool usePostMethod = false)
+        {
+            return FindComponentHistory(client, inputModel, usePostMethod);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the history for the specified component.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="inputModel">The <see cref="ComponentHistoryQueryModel"/> input model.</param>
+        /// <param name="usePostMethod">Contains a value indicating whether the POST method is used in query.</param>
+        /// <returns>Returns a <see cref="ComponentHistoryResultModel"/> model.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <see cref="ComponentHistoryQueryModel"/> is not set.</exception>
+        public static ComponentHistoryResultModel FindComponentHistory(this InspireClient client, ComponentHistoryQueryModel inputModel, bool usePostMethod = false)
         {
             if (inputModel == null)
             {
@@ -807,7 +1113,20 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="componentId">Contains the component identity.</param>
         /// <param name="changesetId">Contains the specific history changeset record identity.</param>
         /// <returns>Returns a <see cref="MinimalComponentHistoryModel"/> model.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentHistoryDetails() going forward. This method will be removed in a future release.")]
         public static MinimalComponentHistoryModel GetComponentHistoryDetails(this InspireClient client, long componentId, Guid changesetId)
+        {
+            return FindComponentHistoryDetails(client, componentId, changesetId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the history for the specified component.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="componentId">Contains the component identity.</param>
+        /// <param name="changesetId">Contains the specific history changeset record identity.</param>
+        /// <returns>Returns a <see cref="MinimalComponentHistoryModel"/> model.</returns>
+        public static MinimalComponentHistoryModel FindComponentHistoryDetails(this InspireClient client, long componentId, Guid changesetId)
         {
             var request = client.CreateRequest($"/Components/{componentId}/History/{changesetId}");
             return client.RequestContent<MinimalComponentHistoryModel>(request);

--- a/src/Components/EditorExtensions.cs
+++ b/src/Components/EditorExtensions.cs
@@ -22,7 +22,19 @@ namespace Vasont.Inspire.SDK.Components
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="model">Contains the component load editor model.</param>
         /// <returns>Returns the <see cref="MinimalEditorXmlModel"/> object that represents the editor record created.</returns>
+        [Obsolete("This method is obsolete. Please use FindEditorComponent() going forward. This method will be removed in a future release.")]
         public static MinimalEditorXmlModel GetEditorComponent(this InspireClient client, EditorLoadModel model)
+        {
+            return FindEditorComponent(client, model);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve the specified Editor Xml Model.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="model">Contains the component load editor model.</param>
+        /// <returns>Returns the <see cref="MinimalEditorXmlModel"/> object that represents the editor record created.</returns>
+        public static MinimalEditorXmlModel FindEditorComponent(this InspireClient client, EditorLoadModel model)
         {
             if (model == null)
             {

--- a/src/Configuration/ConfigurationExtensions.cs
+++ b/src/Configuration/ConfigurationExtensions.cs
@@ -607,6 +607,7 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="componentTypeId">Contains the specific export component type.</param>
         /// <param name="exportType">Contains the <see cref="ExportType"/> type that will be retrieved, Standard is default.</param>
         /// <returns>Returns a list of <see cref="ExportSelectionModel"/> objects from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindExportComponentType() going forward. This method will be removed in a future release.")]
         public static ExportSelectionModel GetExportComponentType(this InspireClient client, long componentTypeId, ExportType exportType = ExportType.Standard)
         {
             return FindExportComponentType(client, componentTypeId, exportType);

--- a/src/Configuration/ConfigurationExtensions.cs
+++ b/src/Configuration/ConfigurationExtensions.cs
@@ -30,7 +30,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="AttributeModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveAttributes() going forward. This method will be removed in a future release.")]
         public static List<AttributeModel> GetAttributes(this InspireClient client)
+        {
+            return RetrieveAttributes(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve and return attributes.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="AttributeModel"/> from the application.</returns>
+        public static List<AttributeModel> RetrieveAttributes(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/Attributes");
             return client.RequestContent<List<AttributeModel>>(request);
@@ -42,7 +53,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="attributeId">Contains the attribute identity to retrieve metadata for.</param>
         /// <returns>Returns a specific <see cref="AttributeModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindAttribute() going forward. This method will be removed in a future release.")]
         public static AttributeModel GetAttribute(this InspireClient client, long attributeId)
+        {
+            return FindAttribute(client, attributeId);
+        }
+
+        /// <summary>
+        /// This Method used to retrieve and return a specific attribute.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="attributeId">Contains the attribute identity to retrieve metadata for.</param>
+        /// <returns>Returns a specific <see cref="AttributeModel"/> from the application.</returns>
+        public static AttributeModel FindAttribute(this InspireClient client, long attributeId)
         {
             var request = client.CreateRequest($"/Configurations/Attributes/{attributeId}");
             return client.RequestContent<AttributeModel>(request);
@@ -104,7 +127,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="MinimalProfileAttributeModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveProfileAttributes() going forward. This method will be removed in a future release.")]
         public static List<MinimalProfileAttributeModel> GetProfileAttributes(this InspireClient client)
+        {
+            return RetrieveProfileAttributes(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of minimal profile attributes.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="MinimalProfileAttributeModel"/> from the application.</returns>
+        public static List<MinimalProfileAttributeModel> RetrieveProfileAttributes(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/ProfileAttributes");
             return client.RequestContent<List<MinimalProfileAttributeModel>>(request);
@@ -115,7 +149,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="ProfileAttributeItemModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveProfileAttributeItems() going forward. This method will be removed in a future release.")]
         public static List<ProfileAttributeItemModel> GetProfileAttributeItems(this InspireClient client)
+        {
+            return RetrieveProfileAttributeItems(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of profile attribute items.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="ProfileAttributeItemModel"/> from the application.</returns>
+        public static List<ProfileAttributeItemModel> RetrieveProfileAttributeItems(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/ProfileAttributes/Selector/Items");
             return client.RequestContent<List<ProfileAttributeItemModel>>(request);
@@ -127,7 +172,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="attributeId">Contains the attribute identity to retrieve metadata for.</param>
         /// <returns>Returns a specific <see cref="ProfileAttributeModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindProfileAttribute() going forward. This method will be removed in a future release.")]
         public static ProfileAttributeModel GetProfileAttribute(this InspireClient client, long attributeId)
+        {
+            return FindProfileAttribute(client, attributeId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific profile attributes.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="attributeId">Contains the attribute identity to retrieve metadata for.</param>
+        /// <returns>Returns a specific <see cref="ProfileAttributeModel"/> from the application.</returns>
+        public static ProfileAttributeModel FindProfileAttribute(this InspireClient client, long attributeId)
         {
             var request = client.CreateRequest($"/Configurations/ProfileAttributes/{attributeId}");
             return client.RequestContent<ProfileAttributeModel>(request);
@@ -189,7 +246,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of schema standards from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveSchemaStandards() going forward. This method will be removed in a future release.")]
         public static List<string> GetSchemaStandards(this InspireClient client)
+        {
+            return RetrieveSchemaStandards(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of schema standards.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of schema standards from the application.</returns>
+        public static List<string> RetrieveSchemaStandards(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/SchemaStandards");
             return client.RequestContent<List<string>>(request);
@@ -204,7 +272,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="ComponentTypeModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveComponentTypes() going forward. This method will be removed in a future release.")]
         public static List<ComponentTypeModel> GetComponentTypes(this InspireClient client)
+        {
+            return RetrieveComponentTypes(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of component types.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="ComponentTypeModel"/> from the application.</returns>
+        public static List<ComponentTypeModel> RetrieveComponentTypes(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/ComponentTypes");
             return client.RequestContent<List<ComponentTypeModel>>(request);
@@ -216,7 +295,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="componentTypeId">Contains the component type identity to retrieve metadata for.</param>
         /// <returns>Returns a specific <see cref="ComponentTypeModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentType() going forward. This method will be removed in a future release.")]
         public static ComponentTypeModel GetComponentType(this InspireClient client, long componentTypeId)
+        {
+            return FindComponentType(client, componentTypeId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific component type.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="componentTypeId">Contains the component type identity to retrieve metadata for.</param>
+        /// <returns>Returns a specific <see cref="ComponentTypeModel"/> from the application.</returns>
+        public static ComponentTypeModel FindComponentType(this InspireClient client, long componentTypeId)
         {
             var request = client.CreateRequest($"/Configurations/ComponentTypes/{componentTypeId}");
             return client.RequestContent<ComponentTypeModel>(request);
@@ -278,7 +369,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="ElementModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveElements() going forward. This method will be removed in a future release.")]
         public static List<ElementModel> GetElements(this InspireClient client)
+        {
+            return RetrieveElements(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of elements.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="ElementModel"/> from the application.</returns>
+        public static List<ElementModel> RetrieveElements(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/Elements");
             return client.RequestContent<List<ElementModel>>(request);
@@ -290,7 +392,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="elementId">Contains the record identity to retrieve.</param>
         /// <returns>Returns a specific <see cref="ElementModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindElement() going forward. This method will be removed in a future release.")]
         public static ElementModel GetElement(this InspireClient client, long elementId)
+        {
+            return FindElement(client, elementId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific element.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="elementId">Contains the record identity to retrieve.</param>
+        /// <returns>Returns a specific <see cref="ElementModel"/> from the application.</returns>
+        public static ElementModel FindElement(this InspireClient client, long elementId)
         {
             var request = client.CreateRequest($"/Configurations/Elements/{elementId}");
             return client.RequestContent<ElementModel>(request);
@@ -352,7 +466,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="ExportConfigurationModel"/> objects from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveExports() going forward. This method will be removed in a future release.")]
         public static List<ExportConfigurationModel> GetExports(this InspireClient client)
+        {
+            return RetrieveExports(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of exports.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="ExportConfigurationModel"/> objects from the application.</returns>
+        public static List<ExportConfigurationModel> RetrieveExports(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/Exports");
             return client.RequestContent<List<ExportConfigurationModel>>(request);
@@ -364,7 +489,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="exportId">Contains the record identity to retrieve.</param>
         /// <returns>Returns a specific <see cref="ExportConfigurationModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindExport() going forward. This method will be removed in a future release.")]
         public static ExportConfigurationModel GetExport(this InspireClient client, long exportId)
+        {
+            return FindExport(client, exportId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific export.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="exportId">Contains the record identity to retrieve.</param>
+        /// <returns>Returns a specific <see cref="ExportConfigurationModel"/> from the application.</returns>
+        public static ExportConfigurationModel FindExport(this InspireClient client, long exportId)
         {
             var request = client.CreateRequest($"/Configurations/Exports/{exportId}");
             return client.RequestContent<ExportConfigurationModel>(request);
@@ -422,7 +559,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="PluginModel"/> objects from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveExportPlugins() going forward. This method will be removed in a future release.")]
         public static List<PluginModel> GetExportPlugins(this InspireClient client)
+        {
+            return RetrieveExportPlugins(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of export plugins.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="PluginModel"/> objects from the application.</returns>
+        public static List<PluginModel> RetrieveExportPlugins(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/Exports/Plugins");
             return client.RequestContent<List<PluginModel>>(request);
@@ -434,7 +582,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="pluginId">Contains the plugin identity to retrieve metadata for.</param>
         /// <returns>Returns a list of <see cref="PluginParameterModel"/> objects from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindExportPluginParameters() going forward. This method will be removed in a future release.")]
         public static List<PluginParameterModel> GetExportPluginParameters(this InspireClient client, long pluginId)
+        {
+            return FindExportPluginParameters(client, pluginId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of export plugin parameters for a specified plugin.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="pluginId">Contains the plugin identity to retrieve metadata for.</param>
+        /// <returns>Returns a list of <see cref="PluginParameterModel"/> objects from the application.</returns>
+        public static List<PluginParameterModel> FindExportPluginParameters(this InspireClient client, long pluginId)
         {
             var request = client.CreateRequest($"/Configurations/Exports/Plugins/{pluginId}/Parameters");
             return client.RequestContent<List<PluginParameterModel>>(request);
@@ -449,6 +609,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <returns>Returns a list of <see cref="ExportSelectionModel"/> objects from the application.</returns>
         public static ExportSelectionModel GetExportComponentType(this InspireClient client, long componentTypeId, ExportType exportType = ExportType.Standard)
         {
+            return FindExportComponentType(client, componentTypeId, exportType);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific export component type selection model.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="componentTypeId">Contains the specific export component type.</param>
+        /// <param name="exportType">Contains the <see cref="ExportType"/> type that will be retrieved, Standard is default.</param>
+        /// <returns>Returns a list of <see cref="ExportSelectionModel"/> objects from the application.</returns>
+        public static ExportSelectionModel FindExportComponentType(this InspireClient client, long componentTypeId, ExportType exportType = ExportType.Standard)
+        {
             var request = client.CreateRequest($"/Configurations/Exports/ComponentTypes/{componentTypeId}?exportType={exportType}");
             return client.RequestContent<ExportSelectionModel>(request);
         }
@@ -462,7 +634,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="LinkMethodModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveLinkMethods() going forward. This method will be removed in a future release.")]
         public static List<LinkMethodModel> GetLinkMethods(this InspireClient client)
+        {
+            return RetrieveLinkMethods(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of link methods.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="LinkMethodModel"/> from the application.</returns>
+        public static List<LinkMethodModel> RetrieveLinkMethods(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/LinkMethods");
             return client.RequestContent<List<LinkMethodModel>>(request);
@@ -477,7 +660,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="XmlLinkTypeModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveXmlLinkTypes() going forward. This method will be removed in a future release.")]
         public static List<XmlLinkTypeModel> GetXmlLinkTypes(this InspireClient client)
+        {
+            return RetrieveXmlLinkTypes(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of XML link types.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="XmlLinkTypeModel"/> from the application.</returns>
+        public static List<XmlLinkTypeModel> RetrieveXmlLinkTypes(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/XmlLinkTypes");
             return client.RequestContent<List<XmlLinkTypeModel>>(request);
@@ -489,7 +683,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="xmlLinkTypeId">Contains the record identity to retrieve.</param>
         /// <returns>Returns a specific <see cref="XmlLinkTypeModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindXmlLinkType() going forward. This method will be removed in a future release.")]
         public static XmlLinkTypeModel GetXmlLinkType(this InspireClient client, long xmlLinkTypeId)
+        {
+            return FindXmlLinkType(client, xmlLinkTypeId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific XML link type.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="xmlLinkTypeId">Contains the record identity to retrieve.</param>
+        /// <returns>Returns a specific <see cref="XmlLinkTypeModel"/> from the application.</returns>
+        public static XmlLinkTypeModel FindXmlLinkType(this InspireClient client, long xmlLinkTypeId)
         {
             var request = client.CreateRequest($"/Configurations/XmlLinkTypes/{xmlLinkTypeId}");
             return client.RequestContent<XmlLinkTypeModel>(request);
@@ -551,7 +757,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="RelationModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveRelations() going forward. This method will be removed in a future release.")]
         public static List<RelationModel> GetRelations(this InspireClient client)
+        {
+            return RetrieveRelations(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of Relation.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="RelationModel"/> from the application.</returns>
+        public static List<RelationModel> RetrieveRelations(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/Relations");
             return client.RequestContent<List<RelationModel>>(request);
@@ -563,7 +780,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="relationId">Contains the record identity to retrieve.</param>
         /// <returns>Returns a specific <see cref="RelationModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindRelation() going forward. This method will be removed in a future release.")]
         public static RelationModel GetRelation(this InspireClient client, long relationId)
+        {
+            return FindRelation(client, relationId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific Relation.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="relationId">Contains the record identity to retrieve.</param>
+        /// <returns>Returns a specific <see cref="RelationModel"/> from the application.</returns>
+        public static RelationModel FindRelation(this InspireClient client, long relationId)
         {
             var request = client.CreateRequest($"/Configurations/Relations/{relationId}");
             return client.RequestContent<RelationModel>(request);
@@ -625,7 +854,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="tagId">Contains the record identity to retrieve.</param>
         /// <returns>Returns a specific <see cref="TagModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindTag() going forward. This method will be removed in a future release.")]
         public static TagModel GetTag(this InspireClient client, long tagId)
+        {
+            return FindTag(client, tagId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific tag.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="tagId">Contains the record identity to retrieve.</param>
+        /// <returns>Returns a specific <see cref="TagModel"/> from the application.</returns>
+        public static TagModel FindTag(this InspireClient client, long tagId)
         {
             var request = client.CreateRequest($"/Configurations/Tags/{tagId}");
             return client.RequestContent<TagModel>(request);
@@ -687,7 +928,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="ProjectActivityModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveProjectActivities() going forward. This method will be removed in a future release.")]
         public static List<ProjectActivityModel> GetProjectActivities(this InspireClient client)
+        {
+            return RetrieveProjectActivities(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of project activities.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="ProjectActivityModel"/> from the application.</returns>
+        public static List<ProjectActivityModel> RetrieveProjectActivities(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/ProjectActivities");
             return client.RequestContent<List<ProjectActivityModel>>(request);
@@ -699,7 +951,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="projectActivityId">Contains the record identity to retrieve.</param>
         /// <returns>Returns a specific <see cref="ProjectActivityModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindProjectActivity() going forward. This method will be removed in a future release.")]
         public static ProjectActivityModel GetProjectActivity(this InspireClient client, long projectActivityId)
+        {
+            return FindProjectActivity(client, projectActivityId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific project activity.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="projectActivityId">Contains the record identity to retrieve.</param>
+        /// <returns>Returns a specific <see cref="ProjectActivityModel"/> from the application.</returns>
+        public static ProjectActivityModel FindProjectActivity(this InspireClient client, long projectActivityId)
         {
             var request = client.CreateRequest($"/Configurations/ProjectActivities/{projectActivityId}");
             return client.RequestContent<ProjectActivityModel>(request);
@@ -761,7 +1025,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="dictionaryOnly">Contains a value indicating whether the languages that are for editor dictionary only are returned.</param>
         /// <returns>Returns a list of <see cref="LanguageModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindLanguages() going forward. This method will be removed in a future release.")]
         public static List<LanguageModel> GetLanguages(this InspireClient client, bool dictionaryOnly = false)
+        {
+            return FindLanguages(client, dictionaryOnly);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of languages.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="dictionaryOnly">Contains a value indicating whether the languages that are for editor dictionary only are returned.</param>
+        /// <returns>Returns a list of <see cref="LanguageModel"/> from the application.</returns>
+        public static List<LanguageModel> FindLanguages(this InspireClient client, bool dictionaryOnly = false)
         {
             var request = client.CreateRequest($"/Languages?dictionaryOnly={dictionaryOnly}");
             return client.RequestContent<List<LanguageModel>>(request);
@@ -773,7 +1049,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="languageCode">Contains the record identity to retrieve.</param>
         /// <returns>Returns a specific <see cref="LanguageModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindLanguage() going forward. This method will be removed in a future release.")]
         public static LanguageModel GetLanguage(this InspireClient client, string languageCode)
+        {
+            return FindLanguage(client, languageCode);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific language.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="languageCode">Contains the record identity to retrieve.</param>
+        /// <returns>Returns a specific <see cref="LanguageModel"/> from the application.</returns>
+        public static LanguageModel FindLanguage(this InspireClient client, string languageCode)
         {
             var request = client.CreateRequest($"/Configurations/Languages/{languageCode}");
             return client.RequestContent<LanguageModel>(request);
@@ -835,7 +1123,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="WebhookConfigurationModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveWebHookConfigurations() going forward. This method will be removed in a future release.")]
         public static List<WebhookConfigurationModel> GetWebHookConfigurations(this InspireClient client)
+        {
+            return RetrieveWebHookConfigurations(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of web hook configurations.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="WebhookConfigurationModel"/> from the application.</returns>
+        public static List<WebhookConfigurationModel> RetrieveWebHookConfigurations(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/WebhookConfigurations");
             return client.RequestContent<List<WebhookConfigurationModel>>(request);
@@ -847,7 +1146,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="webHookConfigurationId">Contains the record identity to retrieve.</param>
         /// <returns>Returns a specific <see cref="WebhookConfigurationModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindWebHookConfiguration() going forward. This method will be removed in a future release.")]
         public static WebhookConfigurationModel GetWebHookConfiguration(this InspireClient client, long webHookConfigurationId)
+        {
+            return FindWebHookConfiguration(client, webHookConfigurationId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific web hook configuration.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="webHookConfigurationId">Contains the record identity to retrieve.</param>
+        /// <returns>Returns a specific <see cref="WebhookConfigurationModel"/> from the application.</returns>
+        public static WebhookConfigurationModel FindWebHookConfiguration(this InspireClient client, long webHookConfigurationId)
         {
             var request = client.CreateRequest($"/Configurations/WebhookConfigurations/{webHookConfigurationId}");
             return client.RequestContent<WebhookConfigurationModel>(request);
@@ -909,7 +1220,18 @@ namespace Vasont.Inspire.SDK.Configuration
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="FileExtensionModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveFileExtensions() going forward. This method will be removed in a future release.")]
         public static List<FileExtensionModel> GetFileExtensions(this InspireClient client)
+        {
+            return RetrieveFileExtensions(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of file extensions.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="FileExtensionModel"/> from the application.</returns>
+        public static List<FileExtensionModel> RetrieveFileExtensions(this InspireClient client)
         {
             var request = client.CreateRequest($"/Configurations/FileExtensions");
             return client.RequestContent<List<FileExtensionModel>>(request);
@@ -921,7 +1243,19 @@ namespace Vasont.Inspire.SDK.Configuration
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="extensionId">Contains the record identity to retrieve.</param>
         /// <returns>Returns a specific <see cref="FileExtensionModel"/> from the application.</returns>
+        [Obsolete("This method is obsolete. Please use FindFileExtension() going forward. This method will be removed in a future release.")]
         public static FileExtensionModel GetFileExtension(this InspireClient client, long extensionId)
+        {
+            return FindFileExtension(client, extensionId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific file extension configuration.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="extensionId">Contains the record identity to retrieve.</param>
+        /// <returns>Returns a specific <see cref="FileExtensionModel"/> from the application.</returns>
+        public static FileExtensionModel FindFileExtension(this InspireClient client, long extensionId)
         {
             var request = client.CreateRequest($"/Configurations/FileExtensions/{extensionId}");
             return client.RequestContent<FileExtensionModel>(request);

--- a/src/Folders/FolderExtensions.cs
+++ b/src/Folders/FolderExtensions.cs
@@ -27,7 +27,22 @@ namespace Vasont.Inspire.SDK.Folders
         /// <param name="includeAllDescendantFolders">Contains a value to indicate whether or not to include all descendant folders.</param>
         /// <param name="permissionFlag">Contains an optional <see cref="PermissionFlags"/> that will be used to filter the results of the query.</param>
         /// <returns>Returns a list of <see cref="FolderBrowseModel"/> objects if found.</returns>
+        [Obsolete("This method is obsolete. Please use FindFoldersByFolderId() going forward. This method will be removed in a future release.")]
         public static List<FolderBrowseModel> GetFoldersByFolderId(this InspireClient client, long folderId, bool includeAllDescendantFolders, PermissionFlags permissionFlag)
+        {
+            return FindFoldersByFolderId(client, folderId, includeAllDescendantFolders, permissionFlag);
+        }
+
+        /// <summary>
+        /// This method is used to return a list of folders that are children of the specified parent folder. 
+        /// If parent folder is not specified, a list of root folders will be returned.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="folderId">Contains the folder identity to retrieve child folders from, pass a value of zero to retrieve all folders.</param>
+        /// <param name="includeAllDescendantFolders">Contains a value to indicate whether or not to include all descendant folders.</param>
+        /// <param name="permissionFlag">Contains an optional <see cref="PermissionFlags"/> that will be used to filter the results of the query.</param>
+        /// <returns>Returns a list of <see cref="FolderBrowseModel"/> objects if found.</returns>
+        public static List<FolderBrowseModel> FindFoldersByFolderId(this InspireClient client, long folderId, bool includeAllDescendantFolders, PermissionFlags permissionFlag)
         {
             if (folderId < 0)
             {
@@ -45,7 +60,20 @@ namespace Vasont.Inspire.SDK.Folders
         /// <param name="folderId">Contains the folder identity to retrieve components from, pass a value of zero to retrieve all components.</param>
         /// <param name="inputModel">Contains the <see cref="FolderComponentsQueryModel"/> input.</param>
         /// <returns>Returns a <see cref="FolderComponentsResultModel"/> object if found.</returns>
+        [Obsolete("This method is obsolete. Please use FindComponentsByFolderId() going forward. This method will be removed in a future release.")]
         public static FolderComponentsResultModel GetComponentsByFolderId(this InspireClient client, long folderId, FolderComponentsQueryModel inputModel)
+        {
+            return FindComponentsByFolderId(client, folderId, inputModel);
+        }
+
+        /// <summary>
+        /// This method is used to return components that are stored within a specific folder matching a specific search criteria.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="folderId">Contains the folder identity to retrieve components from, pass a value of zero to retrieve all components.</param>
+        /// <param name="inputModel">Contains the <see cref="FolderComponentsQueryModel"/> input.</param>
+        /// <returns>Returns a <see cref="FolderComponentsResultModel"/> object if found.</returns>
+        public static FolderComponentsResultModel FindComponentsByFolderId(this InspireClient client, long folderId, FolderComponentsQueryModel inputModel)
         {
             if (folderId < 0)
             {
@@ -63,7 +91,20 @@ namespace Vasont.Inspire.SDK.Folders
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="folderId">Contains the folder identity.</param>
         /// <returns>Returns a list of <see cref="FolderBrowseModel"/> objects if found.</returns>
+        [Obsolete("This method is obsolete. Please use FindAncestorSiblingFoldersByFolderId() going forward. This method will be removed in a future release.")]
         public static List<FolderBrowseModel> GetAncestorSiblingFoldersByFolderId(this InspireClient client, long folderId)
+        {
+            return FindAncestorSiblingFoldersByFolderId(client, folderId);
+        }
+
+        /// <summary>
+        /// This method is used to return a list of folders including the specified folder, 
+        /// its ancestor folders, and corresponding sibling folders.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="folderId">Contains the folder identity.</param>
+        /// <returns>Returns a list of <see cref="FolderBrowseModel"/> objects if found.</returns>
+        public static List<FolderBrowseModel> FindAncestorSiblingFoldersByFolderId(this InspireClient client, long folderId)
         {
             if (folderId <= 0)
             {
@@ -80,7 +121,19 @@ namespace Vasont.Inspire.SDK.Folders
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="folderId">Contains the folder identity.</param>
         /// <returns>Returns a <see cref="PermissionUpdateModel"/> object if found.</returns>
+        [Obsolete("This method is obsolete. Please use FindFolderPermissions() going forward. This method will be removed in a future release.")]
         public static PermissionUpdateModel GetFolderPermissions(this InspireClient client, long folderId)
+        {
+            return FindFolderPermissions(client, folderId);
+        }
+
+        /// <summary>
+        /// This method is used to return folder permission details.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="folderId">Contains the folder identity.</param>
+        /// <returns>Returns a <see cref="PermissionUpdateModel"/> object if found.</returns>
+        public static PermissionUpdateModel FindFolderPermissions(this InspireClient client, long folderId)
         {
             if (folderId <= 0)
             {

--- a/src/Projects/ProjectExtensions.cs
+++ b/src/Projects/ProjectExtensions.cs
@@ -24,7 +24,18 @@ namespace Vasont.Inspire.SDK.Projects
         /// </summary>
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="ProjectModel"/> models.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveProjects() going forward. This method will be removed in a future release.")]
         public static List<ProjectModel> GetProjects(this InspireClient client)
+        {
+            return RetrieveProjects(client);
+        }
+
+        /// <summary>
+        /// This method retrieves the projects that the specified user is assigned membership and/or ownership.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <returns>Returns a list of <see cref="ProjectModel"/> models.</returns>
+        public static List<ProjectModel> RetrieveProjects(this InspireClient client)
         {
             var request = client.CreateRequest($"/Projects");
             return client.RequestContent<List<ProjectModel>>(request);
@@ -36,7 +47,19 @@ namespace Vasont.Inspire.SDK.Projects
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="projectId">Contains the identity for a project to find.</param>
         /// <returns>Returns a <see cref="ProjectModel"/> if found.</returns>
+        [Obsolete("This method is obsolete. Please use FindProject() going forward. This method will be removed in a future release.")]
         public static ProjectModel GetProject(this InspireClient client, long projectId)
+        {
+            return FindProject(client, projectId);
+        }
+
+        /// <summary>
+        /// This method is used to return a project within the system.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="projectId">Contains the identity for a project to find.</param>
+        /// <returns>Returns a <see cref="ProjectModel"/> if found.</returns>
+        public static ProjectModel FindProject(this InspireClient client, long projectId)
         {
             var request = client.CreateRequest($"/Projects/{projectId}");
             return client.RequestContent<ProjectModel>(request);
@@ -48,7 +71,19 @@ namespace Vasont.Inspire.SDK.Projects
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="maximumResults">A value indicating the maximum number of results to return</param>
         /// <returns>Returns a list of <see cref="ProjectModel"/> models.</returns>
+        [Obsolete("This method is obsolete. Please use FindRecentlyOpenedProjects() going forward. This method will be removed in a future release.")]
         public static List<ProjectModel> GetRecentlyOpenedProjects(this InspireClient client, int maximumResults)
+        {
+            return FindRecentlyOpenedProjects(client, maximumResults);
+        }
+
+        /// <summary>
+        /// This method retrieves the projects that the specified user has recently opened.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="maximumResults">A value indicating the maximum number of results to return</param>
+        /// <returns>Returns a list of <see cref="ProjectModel"/> models.</returns>
+        public static List<ProjectModel> FindRecentlyOpenedProjects(this InspireClient client, int maximumResults)
         {
             var request = client.CreateRequest($"/Projects/Recent?maximumResults={maximumResults}");
             return client.RequestContent<List<ProjectModel>>(request);
@@ -59,7 +94,18 @@ namespace Vasont.Inspire.SDK.Projects
         /// </summary>
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="ProjectModel"/> models.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveAssignedProjects() going forward. This method will be removed in a future release.")]
         public static List<ProjectModel> GetAssignedProjects(this InspireClient client)
+        {
+            return RetrieveAssignedProjects(client);
+        }
+
+        /// <summary>
+        /// This method is used to return projects within the system where the given userId is a member.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <returns>Returns a list of <see cref="ProjectModel"/> models.</returns>
+        public static List<ProjectModel> RetrieveAssignedProjects(this InspireClient client)
         {
             var request = client.CreateRequest($"/Projects/Assignments");
             return client.RequestContent<List<ProjectModel>>(request);
@@ -71,7 +117,19 @@ namespace Vasont.Inspire.SDK.Projects
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="projectId">Contains the identity for a project to find.</param>
         /// <returns>Returns a list of <see cref="MinimalUserModel"/> models.</returns>
+        [Obsolete("This method is obsolete. Please use FindAvailableParticipants() going forward. This method will be removed in a future release.")]
         public static List<MinimalUserModel> GetAvailableParticipants(this InspireClient client, long projectId)
+        {
+            return FindAvailableParticipants(client, projectId);
+        }
+
+        /// <summary>
+        /// This method is used to return a list of available participants.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="projectId">Contains the identity for a project to find.</param>
+        /// <returns>Returns a list of <see cref="MinimalUserModel"/> models.</returns>
+        public static List<MinimalUserModel> FindAvailableParticipants(this InspireClient client, long projectId)
         {
             var request = client.CreateRequest($"/Projects/{projectId}/AvailableParticipants");
             return client.RequestContent<List<MinimalUserModel>>(request);
@@ -82,7 +140,18 @@ namespace Vasont.Inspire.SDK.Projects
         /// </summary>
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="ProjectActivityModel"/> models.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveActivities() going forward. This method will be removed in a future release.")]
         public static List<ProjectActivityModel> GetActivities(this InspireClient client)
+        {
+            return RetrieveActivities(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve all the available project activities.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <returns>Returns a list of <see cref="ProjectActivityModel"/> models.</returns>
+        public static List<ProjectActivityModel> RetrieveActivities(this InspireClient client)
         {
             var request = client.CreateRequest($"/Projects/Activities");
             return client.RequestContent<List<ProjectActivityModel>>(request);
@@ -94,7 +163,19 @@ namespace Vasont.Inspire.SDK.Projects
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="projectId">Contains the identity of the project that is being searched for assignments.</param>
         /// <returns>Returns a list of <see cref="ProjectAssignmentModel"/> models.</returns>
+        [Obsolete("This method is obsolete. Please use FindProjectAssignments() going forward. This method will be removed in a future release.")]
         public static List<ProjectAssignmentModel> GetProjectAssignments(this InspireClient client, long projectId)
+        {
+            return FindProjectAssignments(client, projectId);
+        }
+
+        /// <summary>
+        /// This method is used to return project assignments within the system that are associated with a project.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="projectId">Contains the identity of the project that is being searched for assignments.</param>
+        /// <returns>Returns a list of <see cref="ProjectAssignmentModel"/> models.</returns>
+        public static List<ProjectAssignmentModel> FindProjectAssignments(this InspireClient client, long projectId)
         {
             var request = client.CreateRequest($"/Projects/{projectId}/Assignments");
             return client.RequestContent<List<ProjectAssignmentModel>>(request);

--- a/src/Review/ReviewExtensions.cs
+++ b/src/Review/ReviewExtensions.cs
@@ -187,7 +187,7 @@ namespace Vasont.Inspire.SDK.Review
         }
 
         /// <summary>
-        /// This method retrieves the users that that are coordinators.
+        /// This method retrieves the users that are coordinators.
         /// </summary>
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="MinimalUserModel"/> objects if found.</returns>
@@ -198,7 +198,7 @@ namespace Vasont.Inspire.SDK.Review
         }
 
         /// <summary>
-        /// This method retrieves the users that that are coordinators.
+        /// This method retrieves the users that are coordinators.
         /// </summary>
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="MinimalUserModel"/> objects if found.</returns>
@@ -235,8 +235,8 @@ namespace Vasont.Inspire.SDK.Review
         /// <summary>
         /// This method is used to return review components within a review that have been updated after a specified date.
         /// </summary>
-        /// <param name="client">The client.</param>
-        /// <param name="model">The model.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="model">The <see cref="ReviewChangedComponentQueryModel"/> used to Find Changed Review Components.</param>
         /// <returns>Returns a list of <see cref="ReviewerComponentModel"/> objects.</returns>
         public static List<ReviewerComponentModel> FindChangedReviewComponents(this InspireClient client, ReviewChangedComponentQueryModel model)
         {

--- a/src/Review/ReviewExtensions.cs
+++ b/src/Review/ReviewExtensions.cs
@@ -5,8 +5,10 @@
 //-------------------------------------------------------------
 namespace Vasont.Inspire.SDK.Review
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
+    using System.Runtime.CompilerServices;
     using Vasont.Inspire.Models.Reviews;
     using Vasont.Inspire.Models.Security;
     using Vasont.Inspire.Models.Workflow;
@@ -22,7 +24,19 @@ namespace Vasont.Inspire.SDK.Review
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="reviewId">Contains the unique identity of the review.</param>
         /// <returns>Returns a <see cref="ReviewModel"/> model if found.</returns>
+        [Obsolete("This method is obsolete. Please use FindReview() going forward. This method will be removed in a future release.")]
         public static ReviewModel GetReview(this InspireClient client, long reviewId)
+        {
+            return FindReview(client, reviewId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific review model.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="reviewId">Contains the unique identity of the review.</param>
+        /// <returns>Returns a <see cref="ReviewModel"/> model if found.</returns>
+        public static ReviewModel FindReview(this InspireClient client, long reviewId)
         {
             var request = client.CreateRequest($"/Reviews/{reviewId}");
             return client.RequestContent<ReviewModel>(request);
@@ -34,7 +48,19 @@ namespace Vasont.Inspire.SDK.Review
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="reviewId">Contains the unique identity of the review.</param>
         /// <returns>Returns a <see cref="ReviewerEditModel"/> model if found.</returns>
+        [Obsolete("This method is obsolete. Please use FindReviewEdit() going forward. This method will be removed in a future release.")]
         public static ReviewerEditModel GetReviewEdit(this InspireClient client, long reviewId)
+        {
+            return FindReviewEdit(client, reviewId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific edit review model.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="reviewId">Contains the unique identity of the review.</param>
+        /// <returns>Returns a <see cref="ReviewerEditModel"/> model if found.</returns>
+        public static ReviewerEditModel FindReviewEdit(this InspireClient client, long reviewId)
         {
             var request = client.CreateRequest($"/Reviews/{reviewId}/Edit");
             return client.RequestContent<ReviewerEditModel>(request);
@@ -46,7 +72,19 @@ namespace Vasont.Inspire.SDK.Review
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="reviewId">Contains the unique identity of the review.</param>
         /// <returns>Returns a <see cref="ReviewDetailModel"/> model if found.</returns>
+        [Obsolete("This method is obsolete. Please use FindReviewDetail() going forward. This method will be removed in a future release.")]
         public static ReviewDetailModel GetReviewDetail(this InspireClient client, long reviewId)
+        {
+            return FindReviewDetail(client, reviewId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific detailed review model.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="reviewId">Contains the unique identity of the review.</param>
+        /// <returns>Returns a <see cref="ReviewDetailModel"/> model if found.</returns>
+        public static ReviewDetailModel FindReviewDetail(this InspireClient client, long reviewId)
         {
             var request = client.CreateRequest($"/Reviews/{reviewId}/Detail");
             return client.RequestContent<ReviewDetailModel>(request);
@@ -58,7 +96,19 @@ namespace Vasont.Inspire.SDK.Review
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="model">Contains the model for review browsing.</param>
         /// <returns>Returns a <see cref="ReviewBrowseResultModel"/> object.</returns>
+        [Obsolete("This method is obsolete. Please use FindReviews() going forward. This method will be removed in a future release.")]
         public static ReviewBrowseResultModel GetReviews(this InspireClient client, ReviewBrowseQueryModel model)
+        {
+            return FindReviews(client, model);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a review browse result.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="model">Contains the model for review browsing.</param>
+        /// <returns>Returns a <see cref="ReviewBrowseResultModel"/> object.</returns>
+        public static ReviewBrowseResultModel FindReviews(this InspireClient client, ReviewBrowseQueryModel model)
         {
             var request = client.CreateRequest($"/Reviews/Browse", HttpMethod.Post);
             return client.RequestContent<ReviewBrowseQueryModel, ReviewBrowseResultModel>(request, model);
@@ -70,7 +120,19 @@ namespace Vasont.Inspire.SDK.Review
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="reviewId">Contains the review identity.</param>
         /// <returns>Returns a list of <see cref="ReviewComponentModel"/> objects.</returns>
+        [Obsolete("This method is obsolete. Please use FindReviewComponents() going forward. This method will be removed in a future release.")]
         public static List<ReviewComponentModel> GetReviewComponents(this InspireClient client, long reviewId)
+        {
+            return FindReviewComponents(client, reviewId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of associated review components for the specified review.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="reviewId">Contains the review identity.</param>
+        /// <returns>Returns a list of <see cref="ReviewComponentModel"/> objects.</returns>
+        public static List<ReviewComponentModel> FindReviewComponents(this InspireClient client, long reviewId)
         {
             var request = client.CreateRequest($"/Reviews/{reviewId}/Components", HttpMethod.Get);
             return client.RequestContent<List<ReviewComponentModel>>(request);
@@ -83,7 +145,20 @@ namespace Vasont.Inspire.SDK.Review
         /// <param name="reviewId">Contains the review identity.</param>
         /// <param name="reviewComponentId">Contains the review component identity to retrieve.</param>
         /// <returns>Returns the review component <see cref="ReviewComponentModel"/> object.</returns>
+        [Obsolete("This method is obsolete. Please use FindReviewComponent() going forward. This method will be removed in a future release.")]
         public static ReviewComponentModel GetReviewComponent(this InspireClient client, long reviewId, long reviewComponentId)
+        {
+            return FindReviewComponent(client, reviewId, reviewComponentId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a specific review component specified.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="reviewId">Contains the review identity.</param>
+        /// <param name="reviewComponentId">Contains the review component identity to retrieve.</param>
+        /// <returns>Returns the review component <see cref="ReviewComponentModel"/> object.</returns>
+        public static ReviewComponentModel FindReviewComponent(this InspireClient client, long reviewId, long reviewComponentId)
         {
             var request = client.CreateRequest($"/Reviews/{reviewId}/Components/{reviewComponentId}", HttpMethod.Get);
             return client.RequestContent<ReviewComponentModel>(request);
@@ -94,7 +169,18 @@ namespace Vasont.Inspire.SDK.Review
         /// </summary>
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="ReviewAssignmentModel"/> models if found.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveUserReviewAssignments() going forward. This method will be removed in a future release.")]
         public static List<ReviewAssignmentModel> GetUserReviewAssignments(this InspireClient client)
+        {
+            return RetrieveUserReviewAssignments(client);
+        }
+
+        /// <summary>
+        /// This method is used to return active reviews within the system that are associated with the user.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <returns>Returns a list of <see cref="ReviewAssignmentModel"/> models if found.</returns>
+        public static List<ReviewAssignmentModel> RetrieveUserReviewAssignments(this InspireClient client)
         {
             var request = client.CreateRequest($"/Reviews/Assignments");
             return client.RequestContent<List<ReviewAssignmentModel>>(request);
@@ -105,7 +191,18 @@ namespace Vasont.Inspire.SDK.Review
         /// </summary>
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="MinimalUserModel"/> objects if found.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveReviewCoordinators() going forward. This method will be removed in a future release.")]
         public static List<MinimalUserModel> GetReviewCoordinators(this InspireClient client)
+        {
+            return RetrieveReviewCoordinators(client);
+        }
+
+        /// <summary>
+        /// This method retrieves the users that that are coordinators.
+        /// </summary>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <returns>Returns a list of <see cref="MinimalUserModel"/> objects if found.</returns>
+        public static List<MinimalUserModel> RetrieveReviewCoordinators(this InspireClient client)
         {
             var request = client.CreateRequest($"/Reviews/Coordinators");
             return client.RequestContent<List<MinimalUserModel>>(request);
@@ -129,7 +226,19 @@ namespace Vasont.Inspire.SDK.Review
         /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="model">Contains the changed components query model.</param>
         /// <returns>Returns a list of <see cref="ReviewerComponentModel"/> objects.</returns>
+        [Obsolete("This method is obsolete. Please use FindChangedReviewComponents")]
         public static List<ReviewerComponentModel> UpdateReviewComponents(this InspireClient client, ReviewChangedComponentQueryModel model)
+        {
+            return FindChangedReviewComponents(client, model);
+        }
+
+        /// <summary>
+        /// This method is used to return review components within a review that have been updated after a specified date.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="model">The model.</param>
+        /// <returns>Returns a list of <see cref="ReviewerComponentModel"/> objects.</returns>
+        public static List<ReviewerComponentModel> FindChangedReviewComponents(this InspireClient client, ReviewChangedComponentQueryModel model)
         {
             var request = client.CreateRequest($"/Reviews/{model.ReviewId}/Changed", HttpMethod.Post);
             return client.RequestContent<ReviewChangedComponentQueryModel, List<ReviewerComponentModel>>(request, model);

--- a/src/Security/RoleExtensions.cs
+++ b/src/Security/RoleExtensions.cs
@@ -49,7 +49,7 @@ namespace Vasont.Inspire.SDK.Security
         /// <summary>
         /// Gets the specified <see cref="RoleModel"/>.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="roleId">The role identifier.</param>
         /// <returns>Returns the <see cref="RoleModel"/> record of the specified role</returns>
         [Obsolete("This method is obsolete. Please use FindRole() going forward. This method will be removed in a future release.")]
@@ -61,7 +61,7 @@ namespace Vasont.Inspire.SDK.Security
         /// <summary>
         /// Gets the specified <see cref="RoleModel"/>.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="roleId">The role identifier.</param>
         /// <returns>Returns the <see cref="RoleModel"/> record of the specified role</returns>
         public static RoleModel FindRole(this InspireClient client, long roleId)

--- a/src/Security/RoleExtensions.cs
+++ b/src/Security/RoleExtensions.cs
@@ -19,29 +19,55 @@ namespace Vasont.Inspire.SDK.Security
         #region Public Extension Methods
 
         /// <summary>
-        /// This method is used to retrieve a specific <see cref="RoleModel"/> from the system.
+        /// This method is used to retrieve a list of <see cref="RoleModel"/> from the specified query.
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
-        /// <param name="roleId">The role identity.</param>
-        /// <returns>Returns <see cref="RoleModel"/> object if found.</returns>
-        public static RoleModel GetAllRoles(this InspireClient client, long roleId)
+        /// <param name="roleName">Contains an optional value used to filter results by role name.</param>
+        /// <param name="orderBy">Contains an optional value used to specify which model property results will be ordered by.</param>
+        /// <param name="direction">Contains an optional value used to specify which direction results will be ordered.</param>
+        /// <returns>Returns a list of <see cref="RoleModel"/> containing the results of the specified query.</returns>
+        [Obsolete("This method is obsolete. Please use FindRoles() going forward. This method will be removed in a future release.")]
+        public static List<RoleModel> GetRoles(this InspireClient client, string roleName = "", string orderBy = "Name", string direction = "asc")
         {
-            var request = client.CreateRequest($"/Roles/{roleId}");
-            return client.RequestContent<RoleModel>(request);
+            return FindRoles(client, roleName, orderBy, direction);
         }
 
         /// <summary>
-        /// This method is used to retrieve roles that match the search criteria.
+        /// This method is used to retrieve a list of <see cref="RoleModel"/> from the specified query.
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
-        /// <param name="roleName">Name of the role.</param>
-        /// <param name="orderBy">The field to order by the list of roles.</param>
-        /// <param name="direction">The direction of the order by, ascending or descending.</param>
-        /// <returns>Returns <see cref="RoleModel"/> object if found.</returns>
-        public static List<RoleModel> GetRoles(this InspireClient client, string roleName = "", string orderBy = "", string direction = "")
+        /// <param name="roleName">Contains an optional value used to filter results by role name.</param>
+        /// <param name="orderBy">Contains an optional value used to specify which model property results will be ordered by.</param>
+        /// <param name="direction">Contains an optional value used to specify which direction results will be ordered.</param>
+        /// <returns>Returns a list of <see cref="RoleModel"/> containing the results of the specified query.</returns>
+        public static List<RoleModel> FindRoles(this InspireClient client, string roleName = "", string orderBy = "Name", string direction = "asc")
         {
-            var request = client.CreateRequest($"/Roles?roleName={roleName}&orderBy={orderBy}&direction={direction}");
+            var request = client.CreateRequest($"/Roles/{roleName}/{orderBy}/{direction}");
             return client.RequestContent<List<RoleModel>>(request);
+        }
+
+        /// <summary>
+        /// Gets the specified <see cref="RoleModel"/>.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="roleId">The role identifier.</param>
+        /// <returns>Returns the <see cref="RoleModel"/> record of the specified role</returns>
+        [Obsolete("This method is obsolete. Please use FindRole() going forward. This method will be removed in a future release.")]
+        public static RoleModel GetRole(this InspireClient client, long roleId)
+        {
+            return FindRole(client, roleId);
+        }
+
+        /// <summary>
+        /// Gets the specified <see cref="RoleModel"/>.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="roleId">The role identifier.</param>
+        /// <returns>Returns the <see cref="RoleModel"/> record of the specified role</returns>
+        public static RoleModel FindRole(this InspireClient client, long roleId)
+        {
+            var request = client.CreateRequest($"/Roles/{roleId}");
+            return client.RequestContent<RoleModel>(request);
         }
 
         /// <summary>

--- a/src/Security/UserExtensions.cs
+++ b/src/Security/UserExtensions.cs
@@ -24,7 +24,18 @@ namespace Vasont.Inspire.SDK.Security
         /// </summary>
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <returns>Returns a list of <see cref="SelectUserRoleModel"/> objects if found.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveUsers() going forward. This method will be removed in a future release.")]
         public static List<SelectUserRoleModel> GetAllUsers(this InspireClient client)
+        {
+            return RetrieveUsers(client);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve a list of users from the system.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <returns>Returns a list of <see cref="SelectUserRoleModel"/> objects if found.</returns>
+        public static List<SelectUserRoleModel> RetrieveUsers(this InspireClient client)
         {
             var request = client.CreateRequest($"/UserRoles/Users");
             return client.RequestContent<List<SelectUserRoleModel>>(request);
@@ -36,7 +47,19 @@ namespace Vasont.Inspire.SDK.Security
         /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
         /// <param name="userId">Contains the user identity.</param>
         /// <returns>Returns <see cref="UserModel"/> object if found.</returns>
+        [Obsolete("This method is obsolete. Please use FindUser() going forward. This method will be removed in a future release.")]
         public static UserModel GetUser(this InspireClient client, long userId)
+        {
+            return FindUser(client, userId);
+        }
+
+        /// <summary>
+        /// This method is used to retrieve information about a specific user.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="userId">Contains the user identity.</param>
+        /// <returns>Returns <see cref="UserModel"/> object if found.</returns>
+        public static UserModel FindUser(this InspireClient client, long userId)
         {
             var request = client.CreateRequest($"/Users/{userId}");
             return client.RequestContent<UserModel>(request);
@@ -52,7 +75,23 @@ namespace Vasont.Inspire.SDK.Security
         /// <param name="orderBy">Contains the order by field.</param>
         /// <param name="direction">Contains the direction of sort, "ascending" by default.</param>
         /// <returns>Returns a list of <see cref="UserModel"/> objects if found.</returns>
+        [Obsolete("This method is obsolete. Please use FindUsers() going forward. This method will be removed in a future release.")]
         public static List<UserModel> GetUsers(this InspireClient client, string userName = "", string email = "", string phone = "", string orderBy = "UserName", string direction = "ascending")
+        {
+            return FindUsers(client, userName, email, phone, orderBy, direction);
+        }
+
+        /// <summary>
+        /// This method is used to find users based on the search criteria.
+        /// </summary>
+        /// <param name="client">Contains the <see cref="InspireClient"/> that is used for communication.</param>
+        /// <param name="userName">Contains the name of the user.</param>
+        /// <param name="email">Contains the email of the user.</param>
+        /// <param name="phone">Contains the phone number of the user.</param>
+        /// <param name="orderBy">Contains the order by field.</param>
+        /// <param name="direction">Contains the direction of sort, "ascending" by default.</param>
+        /// <returns>Returns a list of <see cref="UserModel"/> objects if found.</returns>
+        public static List<UserModel> FindUsers(this InspireClient client, string userName = "", string email = "", string phone = "", string orderBy = "UserName", string direction = "ascending")
         {
             var request = client.CreateRequest($"/Users?userName={userName}&email={email}&phone={phone}&orderBy={orderBy}&direction={direction}");
             return client.RequestContent<List<UserModel>>(request);

--- a/src/Translations/TranslationsExtensions.cs
+++ b/src/Translations/TranslationsExtensions.cs
@@ -21,7 +21,18 @@ namespace Vasont.Inspire.SDK.Translations
         /// </summary>
         /// <param name="client">Contains the client.</param>
         /// <returns>Returns a list of <see cref="TranslationJobStateModel" /> objects.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveTranslationJobStates() going forward. This method will be removed in a future release.")]
         public static List<TranslationJobStateModel> GetTranslationJobStates(this InspireClient client)
+        {
+            return RetrieveTranslationJobStates(client);
+        }
+
+        /// <summary>
+        /// Get all available translation job states.
+        /// </summary>
+        /// <param name="client">Contains the client.</param>
+        /// <returns>Returns a list of <see cref="TranslationJobStateModel" /> objects.</returns>
+        public static List<TranslationJobStateModel> RetrieveTranslationJobStates(this InspireClient client)
         {
             var request = client.CreateRequest($"/Translations/States");
             return client.RequestContent<List<TranslationJobStateModel>>(request);
@@ -32,7 +43,18 @@ namespace Vasont.Inspire.SDK.Translations
         /// </summary>
         /// <param name="client">The client.</param>
         /// <returns>Returns a List of <see cref="TranslationVendorModel" /> objects.</returns>
+        [Obsolete("This method is obsolete. Please use RetrieveTranslationVendors() going forward. This method will be removed in a future release.")]
         public static List<TranslationVendorModel> GetTranslationVendors(this InspireClient client)
+        {
+            return RetrieveTranslationVendors(client);
+        }
+
+        /// <summary>
+        /// Gets all translation vendors.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <returns>Returns a List of <see cref="TranslationVendorModel" /> objects.</returns>
+        public static List<TranslationVendorModel> RetrieveTranslationVendors(this InspireClient client)
         {
             var request = client.CreateRequest($"/Translations/Vendors");
             return client.RequestContent<List<TranslationVendorModel>>(request);
@@ -44,7 +66,19 @@ namespace Vasont.Inspire.SDK.Translations
         /// <param name="client">The client.</param>
         /// <param name="translationJobId">The translation job identifier.</param>
         /// <returns>Returns the <see cref="TranslationJobModel" /> object found for the requested Id.</returns>
+        [Obsolete("This method is obsolete. Please use FindTranslationJob() going forward. This method will be removed in a future release.")]
         public static TranslationJobModel GetTranslationJobById(this InspireClient client, long translationJobId)
+        {
+            return FindTranslationJob(client, translationJobId);
+        }
+
+        /// <summary>
+        /// Gets the translation job by identifier.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="translationJobId">The translation job identifier.</param>
+        /// <returns>Returns the <see cref="TranslationJobModel" /> object found for the requested Id.</returns>
+        public static TranslationJobModel FindTranslationJob(this InspireClient client, long translationJobId)
         {
             var request = client.CreateRequest($"/Translations/{translationJobId}");
             return client.RequestContent<TranslationJobModel>(request);
@@ -91,7 +125,19 @@ namespace Vasont.Inspire.SDK.Translations
         /// <param name="client">The client.</param>
         /// <param name="translationVendorId">The translation vendor identifier.</param>
         /// <returns>Returns a <see cref="WorkerStateModel" /> of type <see cref="TranslationExportStateModel" />.</returns>
+        [Obsolete("This method is obsolete. Please use FindQueuedTranslationJobs() going forward. This method will be removed in a future release.")]
         public static WorkerStateModel<TranslationExportStateModel> GetQueuedTranslationJobs(this InspireClient client, long translationVendorId)
+        {
+            return FindQueuedTranslationJobs(client, translationVendorId);
+        }
+
+        /// <summary>
+        /// Gets the queued translation jobs.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="translationVendorId">The translation vendor identifier.</param>
+        /// <returns>Returns a <see cref="WorkerStateModel" /> of type <see cref="TranslationExportStateModel" />.</returns>
+        public static WorkerStateModel<TranslationExportStateModel> FindQueuedTranslationJobs(this InspireClient client, long translationVendorId)
         {
             if (translationVendorId <= 0)
             {
@@ -115,7 +161,19 @@ namespace Vasont.Inspire.SDK.Translations
         /// <param name="client">The client.</param>
         /// <param name="workerKey">The worker key.</param>
         /// <returns>Returns a <see cref="WorkerStateModel" /> of type <see cref="TranslationExportStateModel" />.</returns>
+        [Obsolete("This method is obsolete. Please use FindTranslationExportState() going forward. This method will be removed in a future release.")]
         public static MinimalWorkerStateModel<TranslationExportStateModel> GetTranslationExportState(this InspireClient client, string workerKey)
+        {
+            return FindTranslationExportState(client, workerKey);
+        }
+
+        /// <summary>
+        /// Gets the translation export state.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="workerKey">The worker key.</param>
+        /// <returns>Returns a <see cref="WorkerStateModel" /> of type <see cref="TranslationExportStateModel" />.</returns>
+        public static MinimalWorkerStateModel<TranslationExportStateModel> FindTranslationExportState(this InspireClient client, string workerKey)
         {
             if (string.IsNullOrEmpty(workerKey))
             {
@@ -152,7 +210,19 @@ namespace Vasont.Inspire.SDK.Translations
         /// <param name="client">The client.</param>
         /// <param name="translationJobIds">The translation job ids.</param>
         /// <returns>Returns a List of <see cref="TranslationExportJobModel" /> objects.</returns>
+        [Obsolete("This method is obsolete. Please use FindTranslationExportJobs() going forward. This method will be removed in a future release.")]
         public static List<TranslationExportJobModel> GetTranslationExportJobs(this InspireClient client, List<long> translationJobIds)
+        {
+            return FindTranslationExportJobs(client, translationJobIds);
+        }
+
+        /// <summary>
+        /// Gets all of the translation export jobs ready to be processed.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="translationJobIds">The translation job ids.</param>
+        /// <returns>Returns a List of <see cref="TranslationExportJobModel" /> objects.</returns>
+        public static List<TranslationExportJobModel> FindTranslationExportJobs(this InspireClient client, List<long> translationJobIds)
         {
             if (translationJobIds == null)
             {

--- a/src/Translations/TranslationsExtensions.cs
+++ b/src/Translations/TranslationsExtensions.cs
@@ -19,7 +19,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Get all available translation job states.
         /// </summary>
-        /// <param name="client">Contains the client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="TranslationJobStateModel" /> objects.</returns>
         [Obsolete("This method is obsolete. Please use RetrieveTranslationJobStates() going forward. This method will be removed in a future release.")]
         public static List<TranslationJobStateModel> GetTranslationJobStates(this InspireClient client)
@@ -30,7 +30,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Get all available translation job states.
         /// </summary>
-        /// <param name="client">Contains the client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a list of <see cref="TranslationJobStateModel" /> objects.</returns>
         public static List<TranslationJobStateModel> RetrieveTranslationJobStates(this InspireClient client)
         {
@@ -41,7 +41,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Gets all translation vendors.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a List of <see cref="TranslationVendorModel" /> objects.</returns>
         [Obsolete("This method is obsolete. Please use RetrieveTranslationVendors() going forward. This method will be removed in a future release.")]
         public static List<TranslationVendorModel> GetTranslationVendors(this InspireClient client)
@@ -52,7 +52,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Gets all translation vendors.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <returns>Returns a List of <see cref="TranslationVendorModel" /> objects.</returns>
         public static List<TranslationVendorModel> RetrieveTranslationVendors(this InspireClient client)
         {
@@ -63,7 +63,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Gets the translation job by identifier.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="translationJobId">The translation job identifier.</param>
         /// <returns>Returns the <see cref="TranslationJobModel" /> object found for the requested Id.</returns>
         [Obsolete("This method is obsolete. Please use FindTranslationJob() going forward. This method will be removed in a future release.")]
@@ -75,7 +75,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Gets the translation job by identifier.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="translationJobId">The translation job identifier.</param>
         /// <returns>Returns the <see cref="TranslationJobModel" /> object found for the requested Id.</returns>
         public static TranslationJobModel FindTranslationJob(this InspireClient client, long translationJobId)
@@ -87,7 +87,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Finds the translation jobs for the requested translation job Ids.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="translationJobIds">The translation job ids.</param>
         /// <returns>Returns a List of the requested <see cref="MinimalTranslationJobModel" /> objects.</returns>
         public static List<MinimalTranslationJobModel> FindTranslationJobs(this InspireClient client, List<long> translationJobIds)
@@ -105,8 +105,8 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Cancels a Translation Job.
         /// </summary>
-        /// <param name="client">The client.</param>
-        /// <param name="model">The model.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="model">The <see cref="TranslationJobModel"/> used to Cancel the Translation Job.</param>
         /// <returns>Returns the <see cref="TranslationJobModel" /> object that was canceled.</returns>
         public static TranslationJobModel PutTranslationCancel(this InspireClient client, TranslationJobModel model)
         {
@@ -122,7 +122,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Gets the queued translation jobs.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="translationVendorId">The translation vendor identifier.</param>
         /// <returns>Returns a <see cref="WorkerStateModel" /> of type <see cref="TranslationExportStateModel" />.</returns>
         [Obsolete("This method is obsolete. Please use FindQueuedTranslationJobs() going forward. This method will be removed in a future release.")]
@@ -134,7 +134,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Gets the queued translation jobs.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="translationVendorId">The translation vendor identifier.</param>
         /// <returns>Returns a <see cref="WorkerStateModel" /> of type <see cref="TranslationExportStateModel" />.</returns>
         public static WorkerStateModel<TranslationExportStateModel> FindQueuedTranslationJobs(this InspireClient client, long translationVendorId)
@@ -158,7 +158,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Gets the translation export state.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="workerKey">The worker key.</param>
         /// <returns>Returns a <see cref="WorkerStateModel" /> of type <see cref="TranslationExportStateModel" />.</returns>
         [Obsolete("This method is obsolete. Please use FindTranslationExportState() going forward. This method will be removed in a future release.")]
@@ -170,7 +170,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Gets the translation export state.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="workerKey">The worker key.</param>
         /// <returns>Returns a <see cref="WorkerStateModel" /> of type <see cref="TranslationExportStateModel" />.</returns>
         public static MinimalWorkerStateModel<TranslationExportStateModel> FindTranslationExportState(this InspireClient client, string workerKey)
@@ -189,7 +189,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Resets the state of the requested translation components to queued.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="translationComponentIds">The translation component ids to reset state to queued.</param>
         /// <returns>Returns a List of <see cref="MinimalTranslationJobComponentModel" /> objects.</returns>
         public static List<MinimalTranslationJobComponentModel> ResetTranslationComponentsState(this InspireClient client, List<long> translationComponentIds)
@@ -207,7 +207,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Gets all of the translation export jobs ready to be processed.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="translationJobIds">The translation job ids.</param>
         /// <returns>Returns a List of <see cref="TranslationExportJobModel" /> objects.</returns>
         [Obsolete("This method is obsolete. Please use FindTranslationExportJobs() going forward. This method will be removed in a future release.")]
@@ -219,7 +219,7 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Gets all of the translation export jobs ready to be processed.
         /// </summary>
-        /// <param name="client">The client.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
         /// <param name="translationJobIds">The translation job ids.</param>
         /// <returns>Returns a List of <see cref="TranslationExportJobModel" /> objects.</returns>
         public static List<TranslationExportJobModel> FindTranslationExportJobs(this InspireClient client, List<long> translationJobIds)
@@ -237,8 +237,8 @@ namespace Vasont.Inspire.SDK.Translations
         /// <summary>
         /// Sets the translation job statuses for each requested <see cref="TranslationExportJobModel"/>.
         /// </summary>
-        /// <param name="client">The client.</param>
-        /// <param name="models">The models.</param>
+        /// <param name="client"><see cref="InspireClient"/> used to communication with the API endpoint.</param>
+        /// <param name="models">The List of <see cref="TranslationExportJobModel"/> objects used to set translation job statuses.</param>
         /// <returns>Returns a List of <see cref="TranslationExportJobModel" /> objects.</returns>
         public static List<TranslationExportJobModel> SetTranslationJobStatus(this InspireClient client, List<TranslationExportJobModel> models)
         {

--- a/src/Vasont.Inspire.SDK.csproj
+++ b/src/Vasont.Inspire.SDK.csproj
@@ -70,7 +70,7 @@
     </PackageReference>
     <PackageReference Include="IdentityModel" Version="4.3.1" />
     <PackageReference Include="Vasont.Inspire.Core" Version="1.0.16" />
-    <PackageReference Include="Vasont.Inspire.Models" Version="1.1.58" />
+    <PackageReference Include="Vasont.Inspire.Models" Version="1.1.60" />
   </ItemGroup>
   <ItemGroup>
     <XliffResource Include="MultilingualResources\Vasont.Inspire.SDK.de.xlf" />


### PR DESCRIPTION
GetAllRoles method name doesn't match it's function
In the RoleExtensions class there is a GetAllRoles method which returns a role by Id. This is misleading based on the method name.
UpdateReviewComponents method name doesn't match it's function
In the ReviewExtensions class the UpdateReviewComponents method which retrieves a list of changed Review Components. This is misleading based on the method name.

The "Get..." retrieval naming convention is very Java-esk and Rob would like to see these methods renamed to "Find..." and obsolete the "Get..." methods. Make each "Get..." method call the corresponding "Find..." method.